### PR TITLE
Allow to set directly an array of translations

### DIFF
--- a/src/Akeneo/Crowdin/Api/UploadTranslation.php
+++ b/src/Akeneo/Crowdin/Api/UploadTranslation.php
@@ -110,6 +110,17 @@ class UploadTranslation extends AbstractApi
 
         return $this;
     }
+    
+    /**
+     * @param Translation[] $translations
+     * @return UploadTranslation
+     */
+    public function setTranslations(array $translations)
+    {
+        $this->translations = $translations;
+        
+        return $this;
+    }
 
     /**
      * @return Translation[]


### PR DESCRIPTION
The setter is mandatory to be able to re-use the UploadTranslation object for multiple languages